### PR TITLE
Reload bipplugin

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -698,6 +698,15 @@ For the previous example with ``printk`` we could write the following plugin:
                 print("Renaming for {}".format(fu))
                 self.printk_handler(fu.ea)
 
+When testing a ``BipPlugin``, it will often be necessary to reload
+the plugin several times. The easiest way to do that will
+be to use the ``BipPluginManager.reload_plugin``
+method from the ``BipPluginManager`` and to reload
+the file containing the ``BipPlugin`` using the ``Script File...``
+(``Alt+F7``) IDA option. If you want to reload the ``PrintkComs`` plugin,
+re-import the script with ``Alt+F7`` and call the following code:
+``get_plugin_manager().reload_plugin(PrintkComs)``.
+
 
 Similar projects
 ================

--- a/bip/gui/plugin.py
+++ b/bip/gui/plugin.py
@@ -14,7 +14,7 @@ class BipPlugin(object):
         The following code can be used for loading a new plugin:
 
         .. code-block:: python
-            
+
             class MyPlugin(BipPlugin): # define a new class for the plugin
                 pass # implementation
 
@@ -68,7 +68,7 @@ class BipPlugin(object):
             Internal methods which look for the object which inherit from
             :class:`BipActivity` and add them to the ``_activities``
             dictionary.
-            
+
             This functions iter on all items in the object ``__dict__`` and
             the associated class for finding the :class:`BipActivity`.
         """
@@ -105,6 +105,18 @@ class BipPlugin(object):
         for name, action in self._activities.items():
             action.register()
 
+    def _unregister_activities(self):
+        """
+            Internal method which will parcour all the :class:`BipActivity`
+            object which are associated with this plugin and unregister all of
+            them.
+
+            This method is not made for being called directly and should be
+            call by the :meth:`BipPlugin.unload` function.
+        """
+        for name, actions in self._activities.items():
+            actions.unregister()
+
     ############################## LOADING  ################################
 
     @classmethod
@@ -128,8 +140,8 @@ class BipPlugin(object):
         """
             Method which will be called by the :class:`BipPluginManager` when
             the plugin must be loaded.
-            
-            This method can be surcharge by a Plugin for allowing to take
+
+            This method can be surcharge by a plugin for allowing to take
             actions at the moment where it will be loaded.
 
             .. note:: This method is in charge of calling
@@ -139,6 +151,21 @@ class BipPlugin(object):
         """
         self._register_activities()
 
+    def unload(self):
+        """
+            Method which will be called by the :class:`BipPluginManager` when
+            the plugin must be unloaded.
+
+            This method can be surcharge by a plugin for allowing to take
+            actions at the moment where it will be unloaded (such as cleaning
+            stuff).
+
+            .. note:: This method is in charge of calling
+                :meth:`~BipPlugin._unregister_activities` which allow to
+                disable the :class:`BipActivity` link to this plugin.
+                A plugin should ensure to call this method using ``super``.
+        """
+        self._unregister_activities()
 
 def shortcut(shortcut_str):
     """
@@ -154,10 +181,10 @@ def shortcut(shortcut_str):
         .. code-block:: python
 
             class MyPlugin(BipPlugin):
-                
+
                 def my_method(self): # a method inside the plugin
                     print("Hello from MyPlugin.my_method")
-                
+
                 @shortcut("Ctrl-H")
                 def my_shortcut(self):
                     # self is the MyPlugin object
@@ -227,7 +254,7 @@ def menu(menu_path, menu_entry=None):
 
         # get the original method
         of = bac.get_original_method()
-        
+
         if menu_entry is not None:
             lbl = menu_entry
         else:

--- a/bip/gui/pluginmanager.py
+++ b/bip/gui/pluginmanager.py
@@ -265,7 +265,28 @@ class BipPluginManager(idaapi.plugin_t):
             del self._plugins[name]
         return found
 
-    def reload_plugin(self, cls, name=None):
+    def unload_all(self, force=False):
+        """
+            Unload and delete all plugins. If a plugin has been loaded it
+            will be unloaded (calling :meth:`BipPlugin.unload`) first. This
+            is a wrapper on :meth:`~BipPluginManager.unload_plugin` which will
+            be called for all plugins.
+
+            .. note:: This will remove all reference to the plugins classes and
+                objects from the :class:`BipPluginManager`. However, it will
+                (can) not remove any previously fetch reference to the plugin
+                object.
+
+            :param force: See :meth:`~BipPluginManager.unload_plugin`.
+            :raise: if a :meth:`BipPlugin.unload` method of one of the plugin
+                raise an error, this exception will be raised, except if the
+                parameter force is set as True.
+        """
+        plgs = dict(self._plugins)
+        for name in plgs:
+            self.unload_plugin(name, force=force)
+
+    def reload_plugin(self, cls, name=None, force_unload=False):
         """
             Unload, delete then load again a plugin with a new class.
 
@@ -274,16 +295,39 @@ class BipPluginManager(idaapi.plugin_t):
                 the plugin, it is expected to call :meth:`unload_plugin` and
                 then :meth:`addld_plugin`.
 
-            :param cls: The new class (subclass of :class:`BipPlugin`) to load as a plugin.
+            :param cls: The new class (subclass of :class:`BipPlugin`) to load
+                as a plugin.
             :param name: The name for the plugin to reload, if None (the
                 default) the name of the class will be used.
+            :param force_unload: If true (default False) the plugin will be
+                remove from the reference of the :class:`BipPluginManager`
+                even if the :meth:`BipPlugin.unload` method throw an
+                exception. That exception will in that caise not be raise,
+                see :meth:`~BipPluginManager.unload_plugin`.
             :raise: This can raise several exceptions, see :meth:`unload_plugin`
                 and :meth:`addld_plugin`
         """
         if name is None:
             name = cls.__name__
-        self.unload_plugin(name)
+        self.unload_plugin(name, force=force_unload)
         self.addld_plugin(name, cls)
+
+    def reload_all(self, force_unload=False):
+        """
+            Reload all plugins from bip. This will first unload, delete then
+            load all plugins, in particular this means :class:`BipPlugin` for
+            which the method :meth:`~BipPlugin.to_load` has change may be
+            loaded after a call to this method.
+
+            :param force_unload: If true (default False) this function will
+                continue to remove and reload plugins even if one of the
+                :meth:`BipPlugin.unload` method throw an exception. See
+                :meth:`~BipPluginManager.unload_plugin`.
+        """
+        plgs = dict(self._plugins)
+        for name, cls in plgs.items():
+            self.unload_plugin(name, force=force_unload)
+            self.addld_plugin(name, cls)
 
     def __getitem__(self, key):
         """

--- a/bip/gui/pluginmanager.py
+++ b/bip/gui/pluginmanager.py
@@ -20,7 +20,7 @@ class BipPluginManager(idaapi.plugin_t):
         This class also create the ``Bip`` directory as a top level menu
         entry. It is expected that plugins should add their menu actions in
         this directory (using the :func:`menu` decorator).
-        
+
         This object should not be instantiated by the user but should already
         be created when IDA load the plugin. This is a *real* IDAPython plugin
         as understood by IDA.
@@ -33,7 +33,7 @@ class BipPluginManager(idaapi.plugin_t):
     help = "The BipPluginManager is in charge of loading, unloading and in a general way manage BipPlugin objects. See bip documentation for more information."
     wanted_hotkey = "Ctrl-0"
 
-    #: List of module names from which to load the :class:`BipPlugin`, 
+    #: List of module names from which to load the :class:`BipPlugin`,
     #: by default this contains, only the ``bipplugin`` module, but other
     #: can be added by users.
     _modbipplug = ["bipplugin"]
@@ -79,7 +79,7 @@ class BipPluginManager(idaapi.plugin_t):
         """
             Use the :meth:`BipPluginLoader.get_plg_from_files_in_module` for
             locating all :class:`BipPlugin` in a module and load them.
-            
+
             .. note::
 
                 This functions allows to load all plugins define in a
@@ -98,7 +98,7 @@ class BipPluginManager(idaapi.plugin_t):
         """
             Load all plugins which have not already been loaded up to this
             point.
-            
+
             This method is called automatically when the
             :meth:`~BipPluginManager.init` function is called by IDA.
 
@@ -187,7 +187,7 @@ class BipPluginManager(idaapi.plugin_t):
 
     def addld_plugin(self, name, cls, forced=False, ifneeded=False):
         """
-            Add a plugin and try to load it. If the :class`BipPluginManager`
+            Add a plugin and try to load it. If the :class:`BipPluginManager`
             has not already been loaded the plugin will try to be loaded at
             that time (see :meth:`load_one` for details on what loading means
             for a plugin).
@@ -213,7 +213,7 @@ class BipPluginManager(idaapi.plugin_t):
         """
             Get a plugin instance from its name. The plugin must be loaded
             for this method to work.
-            
+
             :param name: A string representing the :class:`BipPlugin` name
                 or a subclass of :class:`BipPlugin`.
             :return: An object (instance) which inherit from
@@ -224,6 +224,41 @@ class BipPluginManager(idaapi.plugin_t):
         if name in self._loaded:
             return self._loaded[name]
         return None
+
+    def unload_plugin(self, name, force=False):
+        """
+            Unload and delete a plugin from its name. If the plugin has been
+            loaded it will be unloaded (calling :meth:`BipPlugin.unload`)
+            first.
+
+            .. note:: This will remove all reference to the plugin class and
+                object from the :class:`BipPluginManager`. However, it will
+                (can) not remove any previously fetch reference to the plugin
+                object.
+
+            :param name: A string representing the :class:`BipPlugin` name
+                or a subclass of :class:`BipPlugin`.
+            :param force: If true (default False) the plugin will be remove
+                from the reference of the :class:`BipPluginManager` even
+                if the :meth:`BipPlugin.unload` method throw an exception
+            :return: True if the plugin was unloaded, False if the plugin
+                was not found.
+            :raise RuntimeError: if the :meth:`BipPlugin.unload` method of
+                the plugin raise a runtime error.
+        """
+        if isinstance(name, type): # a class was given in parameter
+            name = name.__name__
+        found = False
+        if name in self._loaded:
+            found = True
+            p = self._loaded[name]
+            p.unload()
+            del self._loaded[name]
+            del p
+        if name in self._plugins:
+            found = True
+            del self._plugins[name]
+        return found
 
     def __getitem__(self, key):
         """
@@ -249,7 +284,7 @@ class BipPluginManager(idaapi.plugin_t):
         # TODO: this should allow to see and manage plugins
         #   IDA action, mapped on Ctrl-0
         pass
-    
+
     def term(self):
         pass
 

--- a/docs/general/changelog.rst
+++ b/docs/general/changelog.rst
@@ -4,6 +4,24 @@ Changelog
 This page has the goal to record breaking change in the API between versions.
 New features may be listed but probably not always.
 
+Change from v1.0 to Current
+===========================
+
+New features:
+
+* added methods 
+  :meth:`~bip.gui.pluginmanager.BipPluginManager.reload_plugin`,
+  :meth:`~bip.gui.pluginmanager.BipPluginManager.reload_all`,
+  :meth:`~bip.gui.pluginmanager.BipPluginManager.unload_plugin` and
+  :meth:`~bip.gui.pluginmanager.BipPluginManager.unload_all` in the
+  :class:`~bip.gui.pluginmanager.BipPluginManager` for managing
+  :class:`~bip.gui.BipPlugin`.
+* added method :meth:`~bip.gui.BipAction.detach_from_menu`.
+
+Bug Fix:
+
+* Correctly detach :class:`~bip.gui.BipAction` from menu when calling
+  :meth:`~bip.gui.BipAction.unregister`.
 
 Change from v0.3 to v1.0
 ========================

--- a/docs/general/overview.rst
+++ b/docs/general/overview.rst
@@ -560,6 +560,8 @@ the hexrays API. It is also worth noting that all visitors functions provided
 by :class:`HxCFunc` objects are also available directly in :class:`CNode`
 objects to visit only a sub-tree of the full AST.
 
+.. _general-overview-plugins:
+
 Plugins
 =======
 
@@ -665,5 +667,12 @@ For the previous example with ``printk`` we could write the following plugin:
                 print("Renaming for {}".format(fu))
                 self.printk_handler(fu.ea)
 
-
+When testing a :class:`BipPlugin`, it will often be necessary to reload
+the plugin several times. The easiest way to do that will
+be to use the :meth:`~bip.gui.pluginmanager.BipPluginManager.reload_plugin`
+method from the :class:`~bip.gui.pluginmanager.BipPluginManager` and to reload
+the file containing the :class:`BipPlugin` using the ``Script File...``
+(``Alt+F7``) IDA option. If you want to reload the ``PrintkComs`` plugin,
+re-import the script with ``Alt+F7`` and call the following code:
+``get_plugin_manager().reload_plugin(PrintkComs)``.
 

--- a/docs/gui/plgmanager.rst
+++ b/docs/gui/plgmanager.rst
@@ -35,8 +35,17 @@ level of the module for avoiding instantiating a second object which will
 trigger bugs, use :func:`get_plugin_manager` for getting the singleton object.
 
 The :class:`~bip.gui.pluginmanager.BipPluginManager` is also in charge of
-loading automatically 
+loading automatically the plugins located in the ``bipplugin`` folder where
+Bip is installed.
 
+The :meth:`~bip.gui.pluginmanager.BipPluginManager.unload_plugin`,
+:meth:`~bip.gui.pluginmanager.BipPluginManager.reload_plugin`,
+:meth:`~bip.gui.pluginmanager.BipPluginManager.unload_all` and
+:meth:`~bip.gui.pluginmanager.BipPluginManager.reload_all` allow to manage the
+:class:`BipPlugin` which have been loaded. In particular the
+:meth:`~bip.gui.pluginmanager.BipPluginManager.reload_plugin` method is
+practical when developping plugins for making test, for more information see
+TODO
 
 BipPluginManager API
 ====================

--- a/docs/gui/plugin.rst
+++ b/docs/gui/plugin.rst
@@ -24,8 +24,8 @@ A typicall implementation of a plugin will:
   loaded in IDA.
 * use some `activity decorators`_ for declaring actions.
 
-For example of a plugin you can check the :ref:`general-overview` or look at
-the printk plugin.
+For example of a plugin and advice on how to write one, you can check the
+:ref:`general-overview-plugins` part of the :ref:`general-overview`.
 
 .. _gui-plugin-internals:
 

--- a/test/test_bipaction.py
+++ b/test/test_bipaction.py
@@ -52,6 +52,12 @@ def test_bipaction02():
     ta.register()
     assert ta.is_register == True
     assert ta.attach_to_menu("Edit/Plugins/") == True
+    assert len(ta._all_menu_path) == 1
+    assert ta._all_menu_path[0] == "Edit/Plugins/"
+    with pytest.raises(RuntimeError): ta.detach_from_menu("do/not/exist")
+    ta.detach_from_menu("do/not/exist", force=True) # should not do anything
+    ta.detach_from_menu("Edit/Plugins/")
+    assert len(ta._all_menu_path) == 0
     ta2 = BipAction("testm1", handler=lambda *args: 3, path_menu="Edit/Plugins/")
     ta2.register()
     assert ta2.is_register == True

--- a/test/test_bipplugin.py
+++ b/test/test_bipplugin.py
@@ -201,11 +201,19 @@ def test_bipplugin03():
     tp = bpm.get_plugin(Plugin4Test3)
     assert tp.test4load == 1
     assert tp._activities["activity_check"]._activities[0].is_register == True
-    tp.unload()
+    assert "Plugin4Test3" in bpm._plugins
+    assert "Plugin4Test3" in bpm._loaded
+    assert bpm.unload_plugin("Plugin4Test3") == True
+    assert bpm.unload_plugin("Plugin4Test3") == False
+    assert "Plugin4Test3" not in bpm._plugins
+    assert "Plugin4Test3" not in bpm._loaded
     assert tp.test4load == 2
     assert tp._activities["activity_check"]._activities[0].is_register == False
     tp.load()
     assert tp.test4load == 1
     assert tp._activities["activity_check"]._activities[0].is_register == True
+    tp.unload()
+    assert tp.test4load == 2
+    assert tp._activities["activity_check"]._activities[0].is_register == False
 
 

--- a/test/test_bipplugin.py
+++ b/test/test_bipplugin.py
@@ -44,6 +44,7 @@ class Plugin4Test2(BipPlugin):
     def mytest_both(self):
         self.bothcounter += 1
 
+_for_tst3 = 0
 class Plugin4Test3(BipPlugin):
     def __init__(self):
         super(Plugin4Test3, self).__init__()
@@ -53,10 +54,14 @@ class Plugin4Test3(BipPlugin):
     def load(self):
         super(Plugin4Test3, self).load()
         self.test4load = 1
+        global _for_tst3
+        _for_tst3 += 1
 
     def unload(self):
         super(Plugin4Test3, self).unload()
         self.test4load = 2
+        global _for_tst3
+        _for_tst3 += 2
 
     @menu("Edit/Plugins/")
     def activity_check(self):
@@ -196,24 +201,40 @@ def test_bipplugin02():
 
 def test_bipplugin03():
     # Load and unload
+    global _for_tst3
     bpm = get_plugin_manager()
+    assert _for_tst3 == 0
     bpm.addld_plugin("Plugin4Test3", Plugin4Test3)
+    assert _for_tst3 == 1
     tp = bpm.get_plugin(Plugin4Test3)
+    assert isinstance(tp, Plugin4Test3)
     assert tp.test4load == 1
     assert tp._activities["activity_check"]._activities[0].is_register == True
     assert "Plugin4Test3" in bpm._plugins
     assert "Plugin4Test3" in bpm._loaded
     assert bpm.unload_plugin("Plugin4Test3") == True
     assert bpm.unload_plugin("Plugin4Test3") == False
+    assert _for_tst3 == 3
     assert "Plugin4Test3" not in bpm._plugins
     assert "Plugin4Test3" not in bpm._loaded
     assert tp.test4load == 2
     assert tp._activities["activity_check"]._activities[0].is_register == False
     tp.load()
+    assert _for_tst3 == 4
     assert tp.test4load == 1
     assert tp._activities["activity_check"]._activities[0].is_register == True
     tp.unload()
+    assert _for_tst3 == 6
     assert tp.test4load == 2
     assert tp._activities["activity_check"]._activities[0].is_register == False
+    bpm.addld_plugin("Plugin4Test3", Plugin4Test3)
+    assert _for_tst3 == 7
+    bpm.reload_plugin(Plugin4Test3)
+    assert _for_tst3 == 10
+    tp = bpm.get_plugin(Plugin4Test3)
+    assert isinstance(tp, Plugin4Test3)
+    assert bpm.unload_plugin(Plugin4Test3) == True
+    assert _for_tst3 == 12
+
 
 

--- a/test/test_bipplugin.py
+++ b/test/test_bipplugin.py
@@ -223,10 +223,13 @@ def test_bipplugin03():
     assert _for_tst3 == 4
     assert tp.test4load == 1
     assert tp._activities["activity_check"]._activities[0].is_register == True
+    assert len(tp._activities["activity_check"]._activities[0]._all_menu_path) == 1
+    assert tp._activities["activity_check"]._activities[0]._all_menu_path[0] == "Edit/Plugins/"
     tp.unload()
     assert _for_tst3 == 6
     assert tp.test4load == 2
     assert tp._activities["activity_check"]._activities[0].is_register == False
+    assert len(tp._activities["activity_check"]._activities[0]._all_menu_path) == 0
     bpm.addld_plugin("Plugin4Test3", Plugin4Test3)
     assert _for_tst3 == 7
     bpm.reload_plugin(Plugin4Test3)

--- a/test/test_bipplugin.py
+++ b/test/test_bipplugin.py
@@ -44,6 +44,24 @@ class Plugin4Test2(BipPlugin):
     def mytest_both(self):
         self.bothcounter += 1
 
+class Plugin4Test3(BipPlugin):
+    def __init__(self):
+        super(Plugin4Test3, self).__init__()
+        self.test4load = 0
+        self.activ = 0
+
+    def load(self):
+        super(Plugin4Test3, self).load()
+        self.test4load = 1
+
+    def unload(self):
+        super(Plugin4Test3, self).unload()
+        self.test4load = 2
+
+    @menu("Edit/Plugins/")
+    def activity_check(self):
+        self.activ = 1
+
 ### BipPluginLoader ###
 
 def test_bippluginloader00():
@@ -55,7 +73,7 @@ def test_bippluginloader00():
     assert d["Plugin4Test"] == Plugin4Test
     assert d["Plugin4Test2"] == Plugin4Test2
     assert "BipPlugin" not in d
-    assert len(d) == 2
+    assert len(d) == 3
 
 def test_bippluginloader01():
     # get_plg_from_files_in_module
@@ -175,5 +193,19 @@ def test_bipplugin02():
     assert tp.mytest_menu._activities[0].is_register == False
     assert tp.mytest_both._activities[0].is_register == False
     assert tp.mytest_both._activities[1].is_register == False
+
+def test_bipplugin03():
+    # Load and unload
+    bpm = get_plugin_manager()
+    bpm.addld_plugin("Plugin4Test3", Plugin4Test3)
+    tp = bpm.get_plugin(Plugin4Test3)
+    assert tp.test4load == 1
+    assert tp._activities["activity_check"]._activities[0].is_register == True
+    tp.unload()
+    assert tp.test4load == 2
+    assert tp._activities["activity_check"]._activities[0].is_register == False
+    tp.load()
+    assert tp.test4load == 1
+    assert tp._activities["activity_check"]._activities[0].is_register == True
 
 


### PR DESCRIPTION
Add several methods to the `BipPluginManager` and fix bugs in `BipAction` for allowing to reload and unload `BipPlugin`. This also added some doc for how to test a `BipPlugin` during the development.

This merge request as for goal to fix the Issue #3, this should not break any existing API.