### PR TITLE
BipElt prev_*

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -241,13 +241,13 @@ Some static functions are provided to search elements in the database:
     BipInstr: 0x1800D3248 (mov     rdx, r14)
     >>> BipElt.next_code() # find next code elt from current addres or addr passed as arg
     BipInstr: 0x1800D324B (mov     rcx, r13)
-    >>> BipElt.next_code(down=False) # find prev code element
+    >>> BipElt.prev_code() # find prev code element
     BipInstr: 0x1800D3242 (mov     r8d, 8)
     >>> BipElt.next_data() # find next data elt from current address or addr passed as arg
     BipData at 0x1800D3284 = 0xCC (size=1)
-    >>> BipElt.next_data(down=False) # find previous data element
+    >>> BipElt.prev_data() # find previous data element
     BipData at 0x1800D2FE1 = 0xCC (size=1)
-    >>> hex(BipElt.next_data_addr(down=False)) # find address of the previous data element
+    >>> hex(BipElt.prev_data_addr()) # find address of the previous data element
     0x1800d2fe1L
     >>> BipElt.next_unknown() # same for unknown, which are not typed element of IDA and are considered data by Bip
     BipData at 0x180110000 = 0xE (size=1)

--- a/bip/base/bipelt.py
+++ b/bip/base/bipelt.py
@@ -708,6 +708,24 @@ class BipElt(BipRefElt):
         return r
 
     @staticmethod
+    def prev_data_addr(ea=None):
+        """
+            Static method which allow to find the address of the previous data
+            element. Similar to :meth:`next_data_addr` with ``down=False``.
+
+            :param ea: The address at which to start the search. If ``None``
+                the screen address will be used.
+            :return: The address of the next data or None if the search did
+                not find any match.
+        """
+        if ea is None:
+            ea = ida_kernwin.get_screen_ea()
+        r = ida_search.find_data(ea, ida_search.SEARCH_UP)
+        if r == idc.BADADDR: # no data found
+            return None
+        return r
+
+    @staticmethod
     def next_data(ea=None, down=True):
         """
             Static method which allow to find the next data element.
@@ -716,10 +734,27 @@ class BipElt(BipRefElt):
                 the screen address will be used.
             :param down: If True (the default) search below the given
                 address, if False search above.
-            :return: An object which ibherit from :class:`BipBaseElt` or
+            :return: An object which inherit from :class:`BipBaseElt` or
                 ``None`` if the search did not find any match.
         """
         r = BipElt.next_data_addr(ea=ea, down=down)
+        if r is None:
+            return r
+        else:
+            return GetElt(r)
+
+    @staticmethod
+    def prev_data(ea=None):
+        """
+            Static method which allow to find the previous data element.
+            Similar to :meth:`next_data` with ``down=False``.
+
+            :param ea: The address at which to start the search. If ``None``
+                the screen address will be used.
+            :return: An object which inherit from :class:`BipBaseElt` or
+                ``None`` if the search did not find any match.
+        """
+        r = BipElt.prev_data_addr(ea=ea)
         if r is None:
             return r
         else:
@@ -750,6 +785,24 @@ class BipElt(BipRefElt):
         return r
 
     @staticmethod
+    def prev_code_addr(ea=None):
+        """
+            Static method which allow to find the address of the previous code
+            element. Similar to :meth:`next_code_addr` with ``down=False``.
+
+            :param ea: The address at which to start the search. If ``None``
+                the screen address will be used.
+            :return: The address of the previous code or None if the search did
+                not find any match.
+        """
+        if ea is None:
+            ea = ida_kernwin.get_screen_ea()
+        r = ida_search.find_code(ea, ida_search.SEARCH_UP)
+        if r == idc.BADADDR: # no result found
+            return None
+        return r
+
+    @staticmethod
     def next_code(ea=None, down=True):
         """
             Static method which allow to find the next code element.
@@ -758,10 +811,27 @@ class BipElt(BipRefElt):
                 the screen address will be used.
             :param down: If True (the default) search below the given
                 address, if False search above.
-            :return: An object which ibherit from :class:`BipBaseElt` or
+            :return: An object which inherit from :class:`BipBaseElt` or
                 ``None`` if the search did not find any match.
         """
         r = BipElt.next_code_addr(ea=ea, down=down)
+        if r is None:
+            return r
+        else:
+            return GetElt(r)
+
+    @staticmethod
+    def prev_code(ea=None):
+        """
+            Static method which allow to find the previous code element.
+            Similar to :meth:`next_code` with ``down=False``.
+
+            :param ea: The address at which to start the search. If ``None``
+                the screen address will be used.
+            :return: An object which inherit from :class:`BipBaseElt` or
+                ``None`` if the search did not find any match.
+        """
+        r = BipElt.prev_code_addr(ea=ea)
         if r is None:
             return r
         else:
@@ -793,6 +863,26 @@ class BipElt(BipRefElt):
         return r
 
     @staticmethod
+    def prev_unknown_addr(ea=None):
+        """
+            Static method which allow to find the address of the previous unknown
+            element. An unknown element is an element for which IDA does not
+            know the type.
+            Similar to :meth:`next_unkwown_addr` with ``down=False``.
+
+            :param ea: The address at which to start the search. If ``None``
+                the screen address will be used.
+            :return: The address of the previous unknown element or ``None`` if
+                the search did not find any match.
+        """
+        if ea is None:
+            ea = ida_kernwin.get_screen_ea()
+        r = ida_search.find_unknown(ea, ida_search.SEARCH_UP)
+        if r == idc.BADADDR: # no result found
+            return None
+        return r
+
+    @staticmethod
     def next_unknown(ea=None, down=True):
         """
             Static method which allow to find the next unknown element.
@@ -803,10 +893,29 @@ class BipElt(BipRefElt):
                 the screen address will be used.
             :param down: If True (the default) search below the given
                 address, if False search above.
-            :return: An object which ibherit from :class:`BipBaseElt` or
+            :return: An object which inherit from :class:`BipBaseElt` or
                 ``None`` if the search did not find any match.
         """
         r = BipElt.next_unknown_addr(ea=ea, down=down)
+        if r is None:
+            return r
+        else:
+            return GetElt(r)
+
+    @staticmethod
+    def prev_unknown(ea=None):
+        """
+            Static method which allow to find the previous unknown element.
+            An unknown element is an element for which IDA does not know
+            the type.
+            Similar to :meth:`next_unknown` with ``down=False``.
+
+            :param ea: The address at which to start the search. If ``None``
+                the screen address will be used.
+            :return: An object which inherit from :class:`BipBaseElt` or
+                ``None`` if the search did not find any match.
+        """
+        r = BipElt.prev_unknown_addr(ea=ea)
         if r is None:
             return r
         else:
@@ -838,6 +947,26 @@ class BipElt(BipRefElt):
         return r
 
     @staticmethod
+    def prev_defined_addr(ea=None):
+        """
+            Static method which allow to find the address of the previous defined
+            element. An defined element is the opposite of unknown, meaning
+            or a data with a known type or code.
+            Similar to :meth:`next_defined_addr` with ``down=False``.
+
+            :param ea: The address at which to start the search. If ``None``
+                the screen address will be used.
+            :return: The address of the previous defined element or None if
+                the search did not find any match.
+        """
+        if ea is None:
+            ea = ida_kernwin.get_screen_ea()
+        r = ida_search.find_defined(ea, ida_search.SEARCH_UP)
+        if r == idc.BADADDR: # no result found
+            return None
+        return r
+
+    @staticmethod
     def next_defined(ea=None, down=True):
         """
             Static method which allow to find the next defined element.
@@ -848,10 +977,29 @@ class BipElt(BipRefElt):
                 the screen address will be used.
             :param down: If True (the default) search below the given
                 address, if False search above.
-            :return: An object which ibherit from :class:`BipBaseElt` or
+            :return: An object which inherit from :class:`BipBaseElt` or
                 ``None`` if the search did not find any match.
         """
         r = BipElt.next_defined_addr(ea=ea, down=down)
+        if r is None:
+            return r
+        else:
+            return GetElt(r)
+
+    @staticmethod
+    def prev_defined(ea=None):
+        """
+            Static method which allow to find the previous defined element.
+            An defined element is the opposite of unknown, meaning or a data
+            with a known type or code.
+            Similar to :meth:`next_defined` with ``down=False``.
+
+            :param ea: The address at which to start the search. If ``None``
+                the screen address will be used.
+            :return: An object which inherit from :class:`BipBaseElt` or
+                ``None`` if the search did not find any match.
+        """
+        r = BipElt.prev_defined_addr(ea=ea)
         if r is None:
             return r
         else:

--- a/docs/general/overview.rst
+++ b/docs/general/overview.rst
@@ -203,13 +203,13 @@ Some static functions are provided to search elements in the database:
     BipInstr: 0x1800D3248 (mov     rdx, r14)
     >>> BipElt.next_code() # find next code elt from current addres or addr passed as arg
     BipInstr: 0x1800D324B (mov     rcx, r13)
-    >>> BipElt.next_code(down=False) # find prev code element
+    >>> BipElt.prev_code() # find prev code element
     BipInstr: 0x1800D3242 (mov     r8d, 8)
     >>> BipElt.next_data() # find next data elt from current address or addr passed as arg
     BipData at 0x1800D3284 = 0xCC (size=1)
-    >>> BipElt.next_data(down=False) # find previous data element
+    >>> BipElt.prev_data() # find previous data element
     BipData at 0x1800D2FE1 = 0xCC (size=1)
-    >>> hex(BipElt.next_data_addr(down=False)) # find address of the previous data element
+    >>> hex(BipElt.prev_data_addr()) # find address of the previous data element
     0x1800d2fe1L
     >>> BipElt.next_unknown() # same for unknown, which are not typed element of IDA and are considered data by Bip
     BipData at 0x180110000 = 0xE (size=1)

--- a/test/test_bipelt.py
+++ b/test/test_bipelt.py
@@ -135,30 +135,41 @@ def test_bipelt05():
     # next_data
     assert BipElt.next_data_addr(ea=0x1800d324b, down=True) == 0x1800d3284
     assert BipElt.next_data_addr(ea=0x1800d324b, down=False) == 0x1800d2fe1
+    assert BipElt.prev_data_addr(ea=0x1800d324b) == 0x1800d2fe1
     assert BipElt.next_data(ea=0x1800d324b, down=True).ea == 0x1800d3284
     assert BipElt.next_data(ea=0x1800d324b, down=False).ea == 0x1800d2fe1
+    assert BipElt.prev_data(ea=0x1800d324b).ea == 0x1800d2fe1
     # next code
     assert BipElt.next_code_addr(ea=0x1800d324b, down=True) == 0x1800d324e
     assert BipElt.next_code_addr(ea=0x1800d324b, down=False) == 0x1800d3248
+    assert BipElt.prev_code_addr(ea=0x1800d324b) == 0x1800d3248
     assert BipElt.next_code(ea=0x1800d324b, down=True).ea == 0x1800d324e
     assert BipElt.next_code(ea=0x1800d324b, down=False).ea == 0x1800d3248
+    assert BipElt.prev_code(ea=0x1800d324b).ea == 0x1800d3248
     assert isinstance(BipElt.next_code(ea=0x1800d324b, down=True), BipInstr)
     assert isinstance(BipElt.next_code(ea=0x1800d324b, down=False), BipInstr)
+    assert isinstance(BipElt.prev_code(ea=0x1800d324b), BipInstr)
     # next unknown
     assert BipElt.next_unknown_addr(ea=0x1800d324b, down=True) == 0x180110000
     assert BipElt.next_unknown_addr(ea=0x1800d324b, down=False) is None
+    assert BipElt.prev_unknown_addr(ea=0x1800d324b) is None
     assert BipElt.next_unknown_addr(ea=0x180110000, down=True) == 0x180110001
     assert BipElt.next_unknown_addr(ea=0x180110001, down=False) == 0x180110000
+    assert BipElt.prev_unknown_addr(ea=0x180110001) == 0x180110000
     assert BipElt.next_unknown(ea=0x180110000, down=True).ea == 0x180110001
     assert BipElt.next_unknown(ea=0x180110001, down=False).ea == 0x180110000
+    assert BipElt.prev_unknown(ea=0x180110001).ea == 0x180110000
     assert isinstance(BipElt.next_unknown(ea=0x180110000, down=True), BipData)
     assert isinstance(BipElt.next_unknown(ea=0x180110001, down=False), BipData)
+    assert isinstance(BipElt.prev_unknown(ea=0x180110001), BipData)
     # next defined
     assert BipElt.next_defined_addr(ea=0x1800d324b, down=True) == 0x1800d324e
     assert BipElt.next_defined_addr(ea=0x1800d324b, down=False) == 0x1800d3248
+    assert BipElt.prev_defined_addr(ea=0x1800d324b) == 0x1800d3248
     assert BipElt.next_defined_addr(ea=0x180110000, down=True) == 0x180110008
     assert BipElt.next_defined(ea=0x1800d324b, down=True).ea == 0x1800d324e
     assert BipElt.next_defined(ea=0x1800d324b, down=False).ea == 0x1800d3248
+    assert BipElt.prev_defined(ea=0x1800d324b).ea == 0x1800d3248
     assert BipElt.next_defined(ea=0x180110000, down=True).ea == 0x180110008
 
 def test_bipelt06():


### PR DESCRIPTION
Add `BipElt.prev_*` methods as duplicate of existing methods `BipElt.next_*` with the argument `down=False`. This should allow easier and more intuitive usage of the API. Also update the overview for introducing the methods. 