### PR TITLE
Add example for getting a BipFunction from its name in overview

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -118,6 +118,7 @@ The classes ``bip.base.BipFunction`` and ``bip.base.BipBlock``:
     0x1800d2ff0L
     >>> hex(f.end) # end address
     0x1800d3284L
+    >>> f = BipFunction.get_by_name("RtlQueryProcessLockInformation") # fetch the function from its name
     >>> f.name # get and set the name
     RtlQueryProcessLockInformation
     >>> f.name = "test"

--- a/docs/general/overview.rst
+++ b/docs/general/overview.rst
@@ -79,6 +79,7 @@ The classes :class:`~bip.base.BipFunction` and :class:`~bip.base.BipBlock`:
     0x1800d2ff0L
     >>> hex(f.end) # end address
     0x1800d3284L
+    >>> f = BipFunction.get_by_name("RtlQueryProcessLockInformation") # fetch the function from its name
     >>> f.name # get and set the name
     RtlQueryProcessLockInformation
     >>> f.name = "test"


### PR DESCRIPTION
Change to overview for showing `BipFunction.get_by_name`. Hotfix, only doc.