### PR TITLE
README & doc: fix name get_cnode_filter_list by get_cnode_filter_type

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -589,7 +589,7 @@ in both hexrays and the assembly:
 
 While visitors are convenient (and "fast"), Bip also exposes methods to directly
 get the ``CNode`` objects as a list. The methods
-``HxCFunc.get_cnode_filter`` and ``HxCFunc.get_cnode_filter_list``
+``HxCFunc.get_cnode_filter`` and ``HxCFunc.get_cnode_filter_type``
 allow to avoid having a visitor function and make it easier to manipulate
 the hexrays API. It is also worth noting that all visitors functions provided
 by ``HxCFunc`` objects are also available directly in ``CNode``

--- a/docs/general/overview.rst
+++ b/docs/general/overview.rst
@@ -555,7 +555,7 @@ in both hexrays and the assembly:
 
 While visitors are convenient (and "fast"), Bip also exposes methods to directly
 get the :class:`CNode` objects as a list. The methods
-:meth:`HxCFunc.get_cnode_filter` and :meth:`HxCFunc.get_cnode_filter_list`
+:meth:`HxCFunc.get_cnode_filter` and :meth:`HxCFunc.get_cnode_filter_type`
 allow to avoid having a visitor function and make it easier to manipulate
 the hexrays API. It is also worth noting that all visitors functions provided
 by :class:`HxCFunc` objects are also available directly in :class:`CNode`


### PR DESCRIPTION
fix name get_cnode_filter_list by get_cnode_filter_type in overview. Hotfix, only doc.