### PR TITLE
Add interface between BipType and BipFunction

### DIFF
--- a/bip/base/func.py
+++ b/bip/base/func.py
@@ -17,6 +17,7 @@ import bip.base.instr
 import bip.base.block
 import bip.base.xref
 from .biperror import BipError
+from .biptype import BipType
 
 hexrays = None
 
@@ -803,13 +804,46 @@ class BipFunction(object):
         """
         tif = ida_typeinf.tinfo_t()
         if not idaapi.get_type(self.ea, tif, idaapi.GUESSED_FUNC):
-            raise BipError("Unable to get the type for the function {}".format(str(self)))
+            raise BipError("Unable to get the type for {}".format(str(self)))
+        return tif
+
+    @property
+    def type(self):
+        """
+            Property which allow to get or set the :class:`BipType` for this
+            function.
+
+            :return: The :class:`BipType` for this function.
+        """
+        return BipType.from_tinfo(self._ida_tinfo)
+
+    @type.setter
+    def type(self, value):
+        """
+            Setter for the type of the function.
+
+            :param value: An object which inherit from :class:`BipType` or
+                a string (which will be converted using
+                :class:`BipType.from_c`).
+            :raise RuntimeError: If setting the type failed.
+            :raise TypeError: If the argument is not a string or a
+                :class:`BipType` object.
+        """
+        if isinstance(value, (str, unicode)):
+            value = BipType.from_c(value)
+        if not isinstance(value, BipType):
+            raise TypeError("BipFunction.type setter expect a BipType or a string")
+        tif = value._get_tinfo_copy()
+        if not idaapi.set_type(self.ea, tif, idaapi.GUESSED_NONE):
+            raise BipError("Unable to set the type {} for {}".format(tif, str(self)))
         return tif
 
     @property
     def str_type(self):
         """
             Property which return the type (prototype) of the function.
+
+            .. warning:: deprecated, use :meth:`~BipFunction.type` instead.
 
             :return str: String representing the type of the function.
         """
@@ -819,6 +853,8 @@ class BipFunction(object):
     def str_type(self, value):
         """
             Setter which allow to change the type (prototype) of the function.
+
+            .. warning:: deprecated, use :meth:`~BipFunction.type` instead.
         """
         idc.SetType(self.ea, value)
 
@@ -827,6 +863,8 @@ class BipFunction(object):
         """
             Property which allow to return the prototype of the function
             guessed by IDA.
+
+            .. warning:: deprecated, use :meth:`~BipFunction.type` instead.
 
             :return str: The guess prototype of the function.
         """

--- a/bip/base/instr.py
+++ b/bip/base/instr.py
@@ -291,7 +291,7 @@ class BipInstr(BipElt):
                 table.
 
             :return: A list of :class:`BipElt` for the next possible
-                intructions.
+                instructions.
         """
         return [x.dst for x in self.xFrom if x.is_codepath] 
 

--- a/bip/base/instr.py
+++ b/bip/base/instr.py
@@ -286,7 +286,11 @@ class BipInstr(BipElt):
             control flow. This will take call, jmp and ordinary flow into
             account.
 
-            :return: A list of :class:`BipInstr` for the next possible
+            .. note:: In some case this may return :class:`BipData` and not
+                :class:`BipInstr`, this will typically be the case for a jmp
+                table.
+
+            :return: A list of :class:`BipElt` for the next possible
                 intructions.
         """
         return [x.dst for x in self.xFrom if x.is_codepath] 

--- a/docs/general/changelog.rst
+++ b/docs/general/changelog.rst
@@ -17,11 +17,19 @@ New features:
   :class:`~bip.gui.pluginmanager.BipPluginManager` for managing
   :class:`~bip.gui.BipPlugin`.
 * added method :meth:`~bip.gui.BipAction.detach_from_menu`.
+* added property :meth:`~bip.base.BipFunction.type` for interfacing with
+  :class:`~bip.base.BipType`.
 
 Bug Fix:
 
 * Correctly detach :class:`~bip.gui.BipAction` from menu when calling
   :meth:`~bip.gui.BipAction.unregister`.
+
+Deprecated (will be removed on next major version) object & functions:
+
+* Properties :meth:`bip.base.BipFunction.str_type` and
+  :meth:`bip.base.BipFunction.guess_strtype`,
+  should used :meth:`bip.base.BipFunction.type` instead.
 
 Change from v0.3 to v1.0
 ========================

--- a/test/test_bipfunc.py
+++ b/test/test_bipfunc.py
@@ -69,9 +69,9 @@ def test_bipfunc01():
 
 def test_bipfunc02():
     # hexray interface
-    assert BipFunction(0x01800D2FF0).can_decompile == True
-    assert isinstance(BipFunction(0x01800D2FF0).hxcfunc, HxCFunc)
-    assert BipFunction(0x01800D2FF0).hxcfunc.bfunc == BipFunction(0x01800D2FF0)
+    assert BipFunction(0x018010DFC4).can_decompile == True
+    assert isinstance(BipFunction(0x018010DFC4).hxcfunc, HxCFunc)
+    assert BipFunction(0x018010DFC4).hxcfunc.bfunc == BipFunction(0x018010DFC4)
     # TODO: test for decompilation failure
 
 def test_bipfunc03():
@@ -183,13 +183,23 @@ def test_bipfunc06():
 
 def test_bipfunc07():
     # type
+    assert isinstance(BipFunction(0x1800D2FF0)._ida_tinfo, ida_typeinf.tinfo_t)
+    assert isinstance(BipFunction(0x1800D2FF0).type, BTypeFunc)
+    assert BipFunction(0x1800D2FF0).type.str == '__int64 __fastcall()'
+    BipFunction(0x1800D2FF0).type = "void *a(int)"
+    assert BipFunction(0x1800D2FF0).type.str == 'void *__stdcall(int)'
+    BipFunction(0x1800D2FF0).type = BipType.from_c("void *a(int, int)")
+    assert BipFunction(0x1800D2FF0).type.str == 'void *__stdcall(int, int)'
+    BipFunction(0x1800D2FF0).type = "__int64 __fastcall a()"
+    assert BipFunction(0x1800D2FF0).type.str == '__int64 __fastcall()'
+
+    # will be deprecated
     assert BipFunction(0x1800D2FF0).str_type is None
     assert BipFunction(0x1800D2FF0).guess_strtype == '__int64 __fastcall()'
     BipFunction(0x1800D2FF0).str_type = "void *func(int a)"
     assert BipFunction(0x1800D2FF0).str_type == 'void *__stdcall(int a)'
     BipFunction(0x1800D2FF0).str_type = ""
     assert BipFunction(0x1800D2FF0).str_type is None
-    assert isinstance(BipFunction(0x1800D2FF0)._ida_tinfo, ida_typeinf.tinfo_t)
 
 def test_bipfunc08():
     # xref, (j)callers and callees


### PR DESCRIPTION
Add a property (getter and setter) `BipFunction.type` for interfacing `BipFunction` and `BipType`. Deprecate legacy properties `BipFunction.str_type` and `BipFunction.guess_strtype` for being removed in next major released.

Update the changelog and the tests accordingly.