### PR TITLE
add BipData.get_c16string, force for BipFunction.type and add BipInstr.xNonOrdinaryCfNext

### DIFF
--- a/bip/base/data.py
+++ b/bip/base/data.py
@@ -510,7 +510,7 @@ class BipData(BipElt):
             ea = ida_kernwin.get_screen_ea()
         return idc.get_strlit_contents(ea, length=size)
 
-    @statimethod
+    @staticmethod
     def get_c16string(ea=None, size=-1):
         """
             Static method for getting a C16 string (UTF16) from an address.

--- a/bip/base/data.py
+++ b/bip/base/data.py
@@ -510,6 +510,21 @@ class BipData(BipElt):
             ea = ida_kernwin.get_screen_ea()
         return idc.get_strlit_contents(ea, length=size)
 
+    @statimethod
+    def get_c16string(ea=None, size=-1):
+        """
+            Static method for getting a C16 string (UTF16) from an address.
+
+            :param ea: The address of the string. If
+                ``None`` the screen address is used.
+            :param size: The size of the string. If ``-1`` (default), until a
+                ``\0`` is found.
+            :return: Bytes representing the string
+        """
+        if ea is None:
+            ea = ida_kernwin.get_screen_ea()
+        idc.get_strlit_contents(ea, length=size, strtype=STRTYPE_C_16)
+
     @staticmethod
     def get_ptr(ea=None):
         """

--- a/bip/base/data.py
+++ b/bip/base/data.py
@@ -517,13 +517,13 @@ class BipData(BipElt):
 
             :param ea: The address of the string. If
                 ``None`` the screen address is used.
-            :param size: The size of the string. If ``-1`` (default), until a
-                ``\0`` is found.
+            :param size: The size in number of bytes of the string. If ``-1``
+                (default), until a ``\0\0`` is found.
             :return: Bytes representing the string
         """
         if ea is None:
             ea = ida_kernwin.get_screen_ea()
-        idc.get_strlit_contents(ea, length=size, strtype=STRTYPE_C_16)
+        return idc.get_strlit_contents(ea, length=size, strtype=idc.STRTYPE_C_16)
 
     @staticmethod
     def get_ptr(ea=None):

--- a/bip/base/func.py
+++ b/bip/base/func.py
@@ -834,8 +834,8 @@ class BipFunction(object):
         if not isinstance(value, BipType):
             raise TypeError("BipFunction.type setter expect a BipType or a string")
         tif = value._get_tinfo_copy()
-        if not idaapi.set_type(self.ea, tif, idaapi.GUESSED_NONE):
-            raise BipError("Unable to set the type {} for {}".format(tif, str(self)))
+        if not idaapi.set_type(self.ea, tif, idaapi.GUESSED_NONE, True): # force here
+            raise BipError("Unable to set the type {} for {} (even with forced)".format(tif, str(self)))
         return tif
 
     @property

--- a/bip/base/instr.py
+++ b/bip/base/instr.py
@@ -280,6 +280,18 @@ class BipInstr(BipElt):
         return xs[0]
 
     @property
+    def xNonOrdinaryCfNext(self):
+        """
+            Property returning the next instructions in the control flow which
+            are not the following ones. This allows easy access to
+            :class:`BipInstr` for jump and call.
+
+            :return: A list of :class:`BipInstr` for the next instruction in
+                the code path which are not the ordinary control flow.
+        """
+        return [x.dst for x in self.xFrom if x.is_codepath and not x.is_ordinaryflow] 
+
+    @property
     def xCfNext(self):
         """
             Property allowing access to instructions which can follow in the

--- a/test/test_bipdata.py
+++ b/test/test_bipdata.py
@@ -157,6 +157,9 @@ def test_bipdata02():
     assert BipData.get_cstring(0x0180129090) == b'LdrpLoadResourceFromAlternativeModule'
     assert BipData.get_cstring(0x0180129090, size=4) == b'Ldrp'
     assert BipData.get_cstring(0x01801568C5) is None
+    assert BipData.get_c16string(0x0180113EC8) == b'\\AppContainerNamedObjects'
+    assert BipData.get_c16string(0x0180113EC8, size=8) == b'\\App'
+    assert BipData.get_c16string(0x0180113F44) is None
     assert BipData.get_bytes(0x01800D3242, 6) == b'A\xb8\x08\x00\x00\x00'
     BipData.set_bytes(0x01800D3242, "123")
     assert BipData.get_bytes(0x01800D3242, 6) == b'123\x00\x00\x00'

--- a/test/test_bipinstr.py
+++ b/test/test_bipinstr.py
@@ -104,10 +104,14 @@ def test_bipinstr06():
     assert [x.ea for x in BipInstr(0x01800D325A).xCfNext] == [0x01800D325E]
     assert [x.ea for x in BipInstr(0x01800D325A).xCfPrev] == [0x01800D3253, 0x01800D3028]
     assert BipInstr(0x01800D3028).xOrdinaryCfNext is None
+    assert [x.ea for x in BipInstr(0x01800D3028).xNonOrdinaryCfNext] == [0x01800D325A]
     assert [x.ea for x in BipInstr(0x01800D3028).xCfNext] == [0x01800D325A]
     assert [x.ea for x in BipInstr(0x01800D3028).xCfPrev] == [0x01800D3023]
     assert [x.ea for x in BipInstr(0x01800D324E).xCfNext] == [0x01800D3253, 0x01800D35E8]
     assert [x.ea for x in BipInstr(0x01800D323A).xCfNext] == [0x01800D323C, 0x01800D3242]
+    assert [x.ea for x in BipInstr(0x01800D323A).xNonOrdinaryCfNext] == [0x01800D3242]
+    assert BipInstr(0x01800D323A).xOrdinaryCfNext.ea == 0x01800D323C
+    assert [x.ea for x in BipInstr(0x01800D322E).xNonOrdinaryCfNext] == [0x0180009DC0]
 
 def test_bipinstr07():
     # cmp and hash


### PR DESCRIPTION
Several small features and fixes:

* add `BipData.get_c16string` for recuperating an UTF-16 string
* force the setting of the type when using `BipFunction.type`, wierd behavior when not doing this
* add `BipInstr.xNonOrdinaryCfNext` as an opposite function to `BipInstr.xOrdinaryCfNext` for easilly getting the dest of jmps and calls.