### PR TITLE
Small improvements

### DIFF
--- a/bip/base/bipelt.py
+++ b/bip/base/bipelt.py
@@ -210,6 +210,45 @@ class BipRefElt(BipBaseElt):
         """
         return [x.src for x in self.xTo if ('is_code' in dir(x.src) and x.src.is_code)]
 
+    @property
+    def xFuncFrom(self):
+        """
+            Property which return all functions which are referenced by the
+            element. This is similar to :meth:`xCodeFrom` but return a list of
+            :class:`BipFunction` instead of :class:`BipInstr`.
+
+            Each function in the list is unique, if the function could not
+            be found from the :class:`BipInstr` it is ignored.
+
+            :return: A list of :class:`BipFunction` referenced by this element.
+        """
+        l = []
+        for i in self.xCodeFrom:
+            try:
+                l.append(i.func)
+            except Exception:
+                continue
+        return list(set(l))
+
+    @property
+    def xFuncTo(self):
+        """
+            Property which return all functions which referenced this
+            element. This is similar to :meth:`xCodeTo` but return a list of
+            :class:`BipFunction` instead of :class:`BipInstr`.
+
+            Each function in the list is unique, if the function could not
+            be found from the :class:`BipInstr` it is ignored.
+
+            :return: A list of :class:`BipFunction` referenced by this element.
+        """
+        l = []
+        for i in self.xCodeTo:
+            try:
+                l.append(i.func)
+            except Exception:
+                continue
+        return list(set(l))
 
 class BipElt(BipRefElt):
     """

--- a/bip/base/bipstruct.py
+++ b/bip/base/bipstruct.py
@@ -396,6 +396,19 @@ class BipStruct(BipRefElt):
             raise BipError("Impossible to create structure with name={}".format(name))
         return cls(ida_struct.get_struc(sid))
 
+    @classmethod
+    def iter_all(cls):
+        """
+            Class method allowing to iter on all the struct define in the IDB.
+
+            :return: A generator of :class:`BipStruct`.
+        """
+        for i in range(ida_struct.get_first_struc_idx(), ida_struct.get_struc_qty()):
+            sid = ida_struct.get_struc_by_idx(i)
+            if sid == idc.BADADDR:
+                continue # error
+            yield cls(ida_struct.get_struc(sid))
+
     @staticmethod
     def delete(name):
         """

--- a/bip/base/biptype.py
+++ b/bip/base/biptype.py
@@ -84,6 +84,26 @@ class BipType(object):
         """
         return self._tinfo.dstr()
 
+    def get_str_named(self, name=None, comment=None):
+        """
+            Get a string representing the type with a name and a comment.
+
+            :param name: The name to use for the type, if no name is provided
+                (default) it will tried to use the name of the type if any or
+                will just use an empty string.
+            :param comment: The comment (str) for the type. If not set
+                (default) no comment is added.
+        """
+        if comment is None:
+            comment = ""
+        if name is None:
+            if self.is_named:
+                name = self.name
+            else:
+                name = ""
+        return ida_typeinf.print_tinfo("", 1, 1, ida_typeinf.PRTYPE_1LINE,
+            self._tinfo, name, comment)
+
     @property
     def is_named(self):
         """

--- a/bip/base/block.py
+++ b/bip/base/block.py
@@ -434,5 +434,49 @@ class BipBlock(object):
         ida_graph.clr_node_info(self.func.ea, self._id, ida_graph.NIF_BG_COLOR)
         ida_kernwin.refresh_idaview_anyway()
 
+    ############################## STATIC METHODS ############################
+
+    @staticmethod
+    def get(val):
+        """
+            Static method allowing to get a :class:`BipBlock` from different
+            elements. This method is for helping to get a block quickly from
+            different types without having to check for different
+            possibilities.
+
+            This handle getting a :class:`BipBlock` from:
+
+            * a :class:`BipBlock`: return the parameter
+            * an int/long: represent the address of the block
+            * a string: the label of an element inside the block
+            * a :class:`BipInstr`: return the block associated with it
+
+            :param val: the element from which to get the block.
+            :return: A :class:`BipBlock` or None in case of error.
+        """
+        try:
+            if isinstance(val, BipBlock):
+                return val
+            elif isinstance(val, (int, long)):
+                return BipBlock(val)
+            elif isinstance(val, bip.base.instr.BipInstr):
+                return val.block
+            elif isinstance(val, str):
+                elt = bip.base.bipelt.GetEltByName(val)
+                if isinstance(elt, bip.base.instr.BipInstr):
+                    return elt.block
+            return None
+        except Exception:
+            return None
+
+
+
+
+
+
+
+
+
+
 
 

--- a/bip/base/func.py
+++ b/bip/base/func.py
@@ -1106,6 +1106,50 @@ class BipFunction(object):
     ########################## STATIC METHOD ############################
 
     @staticmethod
+    def get(val):
+        """
+            Static method allowing to get a :class:`BipFunction` from different
+            elements. This method is for helping to get a function quickly from
+            different types without having to check for different
+            possibilities.
+
+            This handle getting a :class:`BipFunction` from:
+
+            * a :class:`BipFunction`: return the parameter
+            * an int/long: represent the address of the function
+            * a string: the name of the function
+            * a :class:`BipInstr`: return the function associated with it
+            * a :class:`BipBlock`: return the function associated with it
+            * a :class:`HxCFunc`: return the function associated with it.
+
+            :param val: the element from which to get the function.
+            :return: A :class:`BipFunction` or None in case of error.
+        """
+        global hexrays
+        if hexrays is None:
+            try:
+                import bip.hexrays as hexrays
+            except ImportError:
+                hexrays = None
+        try:
+            if isinstance(val, BipFunction):
+                return val
+            elif isinstance(val, (int, long)):
+                return BipFunction(val)
+            elif isinstance(val, str):
+                return BipFunction.get_by_name(val)
+            elif isinstance(val, bip.base.instr.BipInstr):
+                return val.func
+            elif isinstance(val, bip.base.block.BipBlock):
+                return val.func
+            elif hexrays is not None and isinstance(val, hexrays.HxCFunc):
+                return val.bfunc
+            else:
+                return None
+        except Exception:
+            return None
+
+    @staticmethod
     def count():
         """
             Return the number of functions which are present in the idb.

--- a/bip/base/operand.py
+++ b/bip/base/operand.py
@@ -279,6 +279,22 @@ class BipOperand(object):
                 return self._value
         return self._value
 
+    @property
+    def reg(self):
+        """
+            Property allowing to get the register id number for this operand.
+
+            For register operand this is the same as :meth:`~BipOperand.value`,
+            for "phrase" and "displ" it is the register used.
+
+            :return: The id (int) for the register use by this operand or None
+                if no register is used.
+        """
+        if self.is_reg:
+            return self.value
+        elif self.type == BipOpType.PHRASE or self.type == BipOpType.DISPL:
+            return self._op_t.phrase
+        return None
 
     ######################## TEST TYPE ##########################
 

--- a/bip/hexrays/hx_cexpr.py
+++ b/bip/hexrays/hx_cexpr.py
@@ -1,7 +1,7 @@
 import ida_hexrays
 
 from .hx_citem import HxCType, HxCItem, HxCExpr
-from bip.base import biptype
+from bip.base import biptype, func, data, bipelt
 
 from . import cnode
 
@@ -156,6 +156,32 @@ class HxCExprObj(HxCExprFinal):
             :return int: the address of the object.
         """
         return self._cexpr.obj_ea
+
+    @property
+    def value_as_func(self):
+        """
+            Return the :class:`BipFunction` pointed by this object. If the
+            address do not point on a valid :class:`BipFunction` an exception
+            will be raised.
+        """
+        return func.BipFunction(self.value)
+
+    @property
+    def value_as_cstring(self):
+        """
+            Return a C string pointed by this object. No verification is made
+            that the object point on a valid string.
+        """
+        return data.BipData.get_cstring(self.value)
+
+    @property
+    def value_as_elt(self):
+        """
+            Return a :class:`BipElt` object corresponding to the object
+            pointed by this object. This is equivalent to doing
+            ``GetElt(obj.value)``.
+        """
+        return bipelt.GetElt(self.value)
 
 @cnode.buildCNode
 class HxCExprVar(HxCExprFinal):

--- a/bip/hexrays/hx_cfunc.py
+++ b/bip/hexrays/hx_cfunc.py
@@ -535,3 +535,40 @@ class HxCFunc(object):
         ida_hexrays.clear_cached_cfuncs()
 
 
+    ################################## STATIC METHOD ##########################
+
+    @staticmethod
+    def get(val):
+        """
+            Static method allowing to get a :class:`HxCFunc` from different
+            elements. This method is for helping to get a function quickly from
+            different types without having to check for different
+            possibilities.
+
+            This handle getting a :class:`HxCFunc` from:
+
+            * a :class:`HxCFunc`: return the parameter
+            * a :class:`BipFunction`: return the hexray function associated with it
+            * an int/long: represent the address of the function
+            * a string: the name of the function
+            * a :class:`BipInstr`: return the function associated with it
+
+            :param val: the element from which to get the function.
+            :return: A :class:`HxCFunc` or None in case of error.
+        """
+        try:
+            if isinstance(val, HxCFunc):
+                return val
+            elif isinstance(val, (int, long)):
+                return HxCFunc.from_addr(val)
+            elif isinstance(val, bbase.BipFunction):
+                return val.hxcfunc
+            elif isinstance(val, str):
+                return bbase.BipFunction.get_by_name(val).hxcfunc
+            elif isinstance(val, bbase.BipInstr):
+                return val.func.hxcfunc
+            return None
+        except Exception:
+            return None
+
+

--- a/bip/hexrays/hx_cfunc.py
+++ b/bip/hexrays/hx_cfunc.py
@@ -519,6 +519,24 @@ class HxCFunc(object):
             raise bbase.BipDecompileError("Decompilation failed for {}: address was probably not in a function ?".format(ea))
         return cls(idaobj)
 
+    @classmethod
+    def iter_all(cls):
+        """
+            Class method allowing to iter on all the :class:`HxCFunc` define in
+            the IDB.
+
+            :return: A generator of :class:`HxCFunc` allowing to iter on
+                all the functions define in the idb.
+        """
+        for f in bbase.BipFunction.iter_all():
+            try:
+                yield cls.from_addr(f.ea)
+            except bbase.BipDecompileError:
+                continue
+
+    ################################## STATIC METHOD ##########################
+
+
     @staticmethod
     def invalidate_all_caches():
         """
@@ -533,9 +551,6 @@ class HxCFunc(object):
                 information about this potential problem.
         """
         ida_hexrays.clear_cached_cfuncs()
-
-
-    ################################## STATIC METHOD ##########################
 
     @staticmethod
     def get(val):

--- a/test/test_astnode.py
+++ b/test/test_astnode.py
@@ -155,4 +155,16 @@ def test_bipcnodevisitor00():
     hxf = HxCFunc.from_addr(0x018009BF50)
     hxf.visit_cnode(genst_all)
 
+def test_hxcexprobj00():
+    # Specific test for methods implemented in HxCExprObj/CNodeExprObj
+    f = HxCFunc.from_addr(0x01800D2FF0).get_cnode_filter_type(CNodeExprCall)[0].caller.value_as_func
+    assert isinstance(f, BipFunction)
+    assert f.name == "RtlCommitDebugInfo_0"
+    e = HxCFunc.from_addr(0x01800D2FF0).get_cnode_filter_type(CNodeExprCall)[1].get_arg(0).operand.value_as_elt
+    assert isinstance(e, BipElt) and isinstance(e, BipData)
+    assert e.ea == 0x018015D228
+    s = HxCFunc.from_addr(0x0180053BA0).get_cnode_filter_type(CNodeExprCall)[0].get_arg(1).value_as_cstring
+    assert s == 'SE_InitializeEngine'
+
+
 

--- a/test/test_bipblock.py
+++ b/test/test_bipblock.py
@@ -116,7 +116,15 @@ def test_bipblock05():
     assert BipBlock(0x01800D3242) <= BipBlock(0x01800D3242) 
     assert not (BipBlock(0x01800D3242) < BipBlock(0x01800D3242)) 
 
-
+def test_bipblock06():
+    # static methods
+    assert BipBlock.get(BipBlock(0x01800D3242)) == BipBlock(0x01800D3242)
+    assert BipBlock.get(0x01800D3242) == BipBlock(0x01800D3242)
+    assert BipBlock.get(BipInstr(0x01800D3242)) == BipBlock(0x01800D3242)
+    assert BipBlock.get("loc_1800D3242") == BipBlock(0x01800D3242)
+    assert BipBlock.get([]) is None
+    assert BipBlock.get("DoNotExist") is None
+    assert BipBlock.get(0x018012D400) is None
 
 
 

--- a/test/test_bipelt.py
+++ b/test/test_bipelt.py
@@ -199,19 +199,26 @@ def test_bipelt06():
 
 def test_bipelt07():
     # bipelt xref (just basic test, not the actual test for the BipXref obj)
-    # this basiccally is the test for the BipRefElt
+    # this basically is the test for the BipRefElt
     assert len(BipElt(0x01800D3242).xFrom) == 1
     assert BipElt(0x01800D3242).xFrom[0].src == BipElt(0x01800D3242)
     assert BipElt(0x01800D3242).xFrom[0].dst == BipElt(0x01800D3248)
     assert BipElt(0x01800D3242).xEaFrom == [0x1800d3248]
     assert BipElt(0x01800D3242).xEltFrom == [BipElt(0x01800D3248)]
     assert BipElt(0x01800D3242).xCodeFrom == [BipInstr(0x1800D3248)]
+    assert BipElt(0x01800D3242).xFuncFrom == [BipFunction(0x1800D2FF0)]
+    assert BipElt(0x01800D324E).xFuncFrom == [BipFunction(0x1800D2FF0), BipFunction(0x1800D35E8)]
+    assert BipElt(0x01800D323A).xFuncFrom == [BipFunction(0x1800D2FF0)]
+    assert BipElt(0x018015D238).xFuncFrom == []
     assert len(BipElt(0x01800D3242).xTo) == 1
     assert BipElt(0x01800D3242).xTo[0].src == BipElt(0x01800D323A)
     assert BipElt(0x01800D3242).xTo[0].dst == BipElt(0x01800D3242)
     assert BipElt(0x01800D3242).xEaTo == [0x1800d323A]
     assert BipElt(0x01800D3242).xEltTo == [BipElt(0x01800D323A)]
     assert BipElt(0x01800D3242).xCodeTo == [BipInstr(0x1800D323A)]
+    assert BipElt(0x01800D3242).xFuncTo == [BipFunction(0x1800D2FF0)]
+    assert BipElt(0x01800D324E).xFuncTo == [BipFunction(0x1800D2FF0)]
+    assert BipElt(0x018015D238).xFuncTo == [BipFunction(0x180042174)]
 
 def test_bipelt08():
     # test BipElt.iter_heads

--- a/test/test_bipfunc.py
+++ b/test/test_bipfunc.py
@@ -243,6 +243,14 @@ def test_bipfunc09():
 
 def test_bibfunc0A():
     # static method
+    assert (BipFunction.get(BipFunction(0x180001010)) ==  BipFunction(0x180001010))
+    assert (BipFunction.get(0x180001010) ==  BipFunction(0x180001010))
+    assert (BipFunction.get("RtlFindClearBits") ==  BipFunction(0x180001010))
+    assert (BipFunction.get(BipInstr(0x180001010)) ==  BipFunction(0x180001010))
+    assert (BipFunction.get(BipBlock(0x180001010)) ==  BipFunction(0x180001010))
+    assert (BipFunction.get(BipFunction(0x180001010).hxcfunc) ==  BipFunction(0x180001010))
+    assert (BipFunction.get([]) is None)
+    assert (BipFunction.get("DoNotExist") is None)
     assert BipFunction.count() == 0xecd
 
 

--- a/test/test_bipoperand.py
+++ b/test/test_bipoperand.py
@@ -30,6 +30,13 @@ def test_bipoperand00():
     assert GetElt(0x01800D3094).op(1).value == 0xc0000017
 
 def test_bipoperand01():
+    # test .reg
+    assert GetElt(0x01800D3242).op(0).reg == 8
+    assert GetElt(0x01800D3242).op(1).reg is None
+    assert GetElt(0x01800D323C).op(0).reg == 0xD
+    assert GetElt(0x01800D31E9).op(0).reg == 0xE
+
+def test_bipoperand02():
     # test type
     assert GetElt(0x01800D314C).op(0).is_void == False # reg
     assert GetElt(0x01800D314C).op(0).is_reg == True

--- a/test/test_bipstruct.py
+++ b/test/test_bipstruct.py
@@ -17,10 +17,14 @@ def test_bipstruct00():
     assert isinstance(st, BipStruct)
     with pytest.raises(ValueError): BipStruct.get("DoNotExist")
     with pytest.raises(ValueError): BipStruct.create("_UNWIND_HISTORY_TABLE")
+    assert isinstance(next(BipStruct.iter_all()), BipStruct)
+    assert next(BipStruct.iter_all()).name == "GUID"
+    assert len([s for s in BipStruct.iter_all()]) == 0x15
     st = BipStruct.create("newStruct")
     assert isinstance(st, BipStruct)
     st = BipStruct.get("newStruct")
     assert isinstance(st, BipStruct)
+    assert len([s for s in BipStruct.iter_all()]) == 0x16
     BipStruct.delete("newStruct")
     with pytest.raises(ValueError): BipStruct.get("newStruct")
     with pytest.raises(ValueError): BipStruct.delete("newStruct")

--- a/test/test_biptype.py
+++ b/test/test_biptype.py
@@ -281,6 +281,22 @@ def test_biptype0F():
     with pytest.raises(ValueError): BipStruct.get("testd") # not automatically import, so this should fail
     assert isinstance(BipStruct.get("teste"), BipStruct)
 
+def test_biptype10():
+    # get_named_type
+    ty = BipType.from_c("int");
+    assert ty.str == 'int'
+    assert ty.get_str_named(name="i", comment = "com2") == 'int i /* com2 */'
+    ty = BipType.from_c("int [8]");
+    assert ty.str == 'int[8]'
+    assert ty.get_str_named() == 'int[8]'
+    assert ty.get_str_named(name="test") == 'int test[8]'
+    assert ty.get_str_named(name="test", comment="123") == 'int test[8] /* 123 */'
+    assert ty.get_str_named(comment="123") == 'int[8] /* 123 */'
+    ty = BipType.from_c("void (*f)(int a, void *b)");
+    assert ty.str == 'void (__stdcall *)(int a, void *b)'
+    assert ty.get_str_named() == 'void (__stdcall *)(int a, void *b)'
+    assert ty.get_str_named(name="f") == 'void (__stdcall *f)(int a, void *b)'
+    assert ty.get_str_named(name="f", comment = "com") == 'void (__stdcall *f)(int a, void *b) /* com */'
 
 
 

--- a/test/test_hxcfunc.py
+++ b/test/test_hxcfunc.py
@@ -27,6 +27,9 @@ def test_biphxcfunc00():
     hxf.invalidate_cache() # just check it exist and do not raise an exception
     hxf = HxCFunc.from_addr(0x01800D2FF0)
     HxCFunc.invalidate_all_caches() # same as before
+    hxf2 = next(HxCFunc.iter_all())
+    assert isinstance(hxf2, HxCFunc)
+    assert hxf2.ea == 0x180001010
 
 def test_biphxcfunc01():
     # cmp

--- a/test/test_hxcfunc.py
+++ b/test/test_hxcfunc.py
@@ -1,5 +1,5 @@
 from bip.hexrays import *
-from bip.base import BipDecompileError, BipFunction
+from bip.base import BipDecompileError, BipFunction, BipInstr
 
 import idc
 
@@ -11,7 +11,7 @@ import pytest
 """
 
 def test_biphxcfunc00():
-    # hxcfunc base, other and class/static methods
+    # hxcfunc base, other and class methods
     hxf = HxCFunc.from_addr(0x01800D2FF0)
     assert isinstance(hxf, HxCFunc)
     assert hxf.ea == 0x01800D2FF0
@@ -78,5 +78,16 @@ def test_biphxcfunc04():
     assert hxf.root_node.hxcfunc == hxf
     assert hxf.hx_root_stmt is not None
     assert isinstance(hxf.hx_root_stmt, HxCStmtBlock)
+
+def test_biphxcfunc05():
+    # static methods
+    assert HxCFunc.get(HxCFunc.from_addr(0x01800D2FF0)).ea == 0x01800D2FF0
+    assert HxCFunc.get(0x01800D2FF0).ea == 0x01800D2FF0
+    assert HxCFunc.get("RtlQueryProcessLockInformation").ea == 0x01800D2FF0
+    assert HxCFunc.get(BipFunction(0x01800D2FF0)).ea == 0x01800D2FF0
+    assert HxCFunc.get(BipInstr(0x01800D2FF0)).ea == 0x01800D2FF0
+
+
+
 
 


### PR DESCRIPTION
This PR regroup several small improvements:

* add `BipOperand.reg` for getting the register number use in an operand
* add `get` static method to `BipFunction`, `BipBlock` and `HxCFunc` for allowing getting those object from different argument type
* adding `HxCFunc.iter_all` and `BipStruct.iter_all` methods for iterating on all those objects
* adding `BipType.get_str_named` for making it easier to generate valid C from IDA types
* add methods for easier access to underlying objects pointed by `CNodeExprObj` and `HxCExprObj`

No breaking change in those modifications, test for all of those should be good.