### PR TITLE
Small features in BipFunction, BipElt, BipStruct and BipType

### DIFF
--- a/bip/base/bipelt.py
+++ b/bip/base/bipelt.py
@@ -5,6 +5,8 @@ import ida_bytes
 import ida_name
 import ida_search
 
+import re
+
 from bip.py3compat.py3compat import *
 
 import bip.base.xref
@@ -706,6 +708,44 @@ class BipElt(BipRefElt):
             if cls._is_this_elt(ea):
                 yield elt
             ea += sz
+
+    @classmethod
+    def iter_by_regex(cls, regex):
+        """
+            Class method allowing to get all :class:`BipElt` matching a regex.
+
+            Internally this iterate on all elts (using ``iter_all``) and use
+            the ``re.match`` function (it compiles the regex first) and return
+            only the elements which match the regex (did not return None) and
+            have the correct type.
+
+            :param str regex: The regex used for finding the function.
+            :return: An iterator (yield) of :class:`BipElt` where their names
+                match the regex.
+        """
+        rc = re.compile(regex)
+        for e in cls.iter_all():
+            if rc.match(e.name) is not None:
+                yield e
+
+    @classmethod
+    def get_by_regex(cls, regex):
+        """
+            Class method allowing to get all :class:`BipElt` matching a regex.
+
+            Internally this iterate on all elts and use the ``re.match``
+            function (it compiles the regex first) and return only the elements
+            which match the regex (did not return None) and have the correct
+            type.
+
+            .. note:: This is similar to iter_by_regex, except return a list
+                instead of an iterator.
+
+            :param str regex: The regex used for finding the function.
+            :return: A list of :class:`BipElt` where their names match
+                the regex.
+        """
+        return [e for e in cls.iter_by_regex(regex)]
 
     #################### STATIC METHOD ######################
 

--- a/bip/base/bipelt.py
+++ b/bip/base/bipelt.py
@@ -719,7 +719,7 @@ class BipElt(BipRefElt):
             only the elements which match the regex (did not return None) and
             have the correct type.
 
-            :param str regex: The regex used for finding the function.
+            :param str regex: The regex used for finding the elements.
             :return: An iterator (yield) of :class:`BipElt` where their names
                 match the regex.
         """
@@ -741,11 +741,47 @@ class BipElt(BipRefElt):
             .. note:: This is similar to iter_by_regex, except return a list
                 instead of an iterator.
 
-            :param str regex: The regex used for finding the function.
+            :param str regex: The regex used for finding the elements.
             :return: A list of :class:`BipElt` where their names match
                 the regex.
         """
         return [e for e in cls.iter_by_regex(regex)]
+
+    @classmethod
+    def iter_by_prefix(cls, prefix):
+        """
+            Class method allowing to get all :class:`BipElt` starting with
+            a prefix.
+
+            Internally this iterate on all elts (using ``iter_all``) and if
+            they have a name check that they start with the prefix. Do not
+            expect any performance from this function.
+
+            :param str prefix: The prefix used for finding the elts.
+            :return: An iterator (yield) of :class:`BipElt` where their names
+                match the prefix.
+        """
+        for e in cls.iter_all():
+            if e.name is not None and e.name != "" and e.name.startswith(prefix):
+                yield e
+
+    @classmethod
+    def get_by_prefix(cls, prefix):
+        """
+            Class method allowing to get all :class:`BipElt` matching a prefix.
+
+            This will iterate on all elts and check their name. Do not
+            expect any performance from this function.
+
+            .. note:: This is similar to iter_by_prefix, except return a list
+                instead of an iterator.
+
+            :param str prefix: The prefix used for finding the function.
+            :return: A list of :class:`BipElt` where their names match
+                the prefix.
+        """
+        return [e for e in cls.iter_by_prefix(prefix)]
+
 
     #################### STATIC METHOD ######################
 

--- a/bip/base/bipstruct.py
+++ b/bip/base/bipstruct.py
@@ -6,7 +6,8 @@ import ida_typeinf
 from bip.py3compat.py3compat import *
 
 from .bipidb import BipIdb
-from .biptype import BipType
+#from .biptype import BipType
+import bip.base.biptype
 from .bipelt import BipRefElt
 from .biperror import BipError
 
@@ -397,6 +398,16 @@ class BipStruct(BipRefElt):
         return cls(ida_struct.get_struc(sid))
 
     @classmethod
+    def exist(cls, name):
+        """
+            Class method for checking if a struct with a name exist. Return
+            True if it does, False otherwise.
+
+            :param str name: The name of the structure to test.
+        """
+        return ida_struct.get_struc_id(name) != idc.BADADDR
+
+    @classmethod
     def iter_all(cls):
         """
             Class method allowing to iter on all the struct define in the IDB.
@@ -622,7 +633,7 @@ class BStructMember(BipRefElt):
     def type(self):
         """
             Property which return an object which inherit from
-            :class:`BipType` and represent the type of this member.
+            :class:`~bip.base.biptype.BipType` and represent the type of this member.
 
             :raise RuntimeError: If it was not possible to get the type of
                 this member, this may happen in particular if
@@ -631,7 +642,7 @@ class BStructMember(BipRefElt):
         ti = ida_typeinf.tinfo_t()
         if not ida_struct.get_member_tinfo(ti, self._member):
             raise RuntimeError("Could not get the type for {}".format(self))
-        return BipType.from_tinfo(ti)
+        return bip.base.biptype.BipType.from_tinfo(ti)
 
     def del_type(self):
         """
@@ -646,7 +657,7 @@ class BStructMember(BipRefElt):
         """
             Method which allow to change the type of this member.
 
-            :param new_type: An object which inherit from :class:`BipType`
+            :param new_type: An object which inherit from :class:`~bip.base.biptype.BipType`
                 which represent the new type for this member.
             :param bool userspecified: Is this type specified by the user,
                 True by default.
@@ -660,9 +671,9 @@ class BStructMember(BipRefElt):
             :param bool bytil: The new type was created by the type subsystem.
                 Default False.
             :raise RuntimeError: If setting the type failed.
-            :raise TypeError: If the argument is not an :class:`BipType` object.
+            :raise TypeError: If the argument is not an :class:`~bip.base.biptype.BipType` object.
         """
-        if not isinstance(new_type, BipType):
+        if not isinstance(new_type, bip.base.biptype.BipType):
             raise TypeError("BStructMember.set_type setter expect an object which inherit from BipType")
         # compute the flags, from SET_MEMTI_* in struct.hpp
         flags = 0
@@ -692,20 +703,20 @@ class BStructMember(BipRefElt):
             .. note::
 
                 This will create a copy of the type for avoiding problem with
-                the IDA interface. See :class:`BipType` for more information.
+                the IDA interface. See :class:`~bip.base.biptype.BipType` for more information.
 
-            :param value: An object which inherit from :class:`BipType` which
+            :param value: An object which inherit from :class:`~bip.base.biptype.BipType` which
                 represent the new type for this member or a string
                 representing a declaration in C.
             :raise RuntimeError: If setting the type failed.
             :raise TypeError: If the argument is not None, a string or a
-                :class:`BipType` object.
+                :class:`~bip.base.biptype.BipType` object.
         """
         if value is None:
             self.del_type()
             return
         if isinstance(value, (str, unicode)):
-            value = BipType.from_c(value)
+            value = bip.base.biptype.BipType.from_c(value)
         self.set_type(value)
 
     @property

--- a/bip/base/bipstruct.py
+++ b/bip/base/bipstruct.py
@@ -527,6 +527,28 @@ class BStructMember(BipRefElt):
         """
         return ida_struct.get_member_size(self._member)
 
+    @size.setter
+    def size(self, value):
+        """
+            Setter for the size of a member.
+
+            :param value: The size to set in bytes (1, 2, 4 or 8), if 0 is set,
+                this will set the member as being of variable size.
+            :raise RuntimeError: If it was not possible to set the size for the
+                member. This typically occurs when another member is define
+                after it, or if setting a variable size not at the end of a
+                structure.
+            :raise ValueError: If the value parameter is not correct.
+        """
+        if value not in (0, 1, 2, 4, 8):
+            raise ValueError("Size to set for BStructMember.size is not valid")
+        flags = idc.FF_DATA
+        d= {8:idc.FF_QWORD, 4:idc.FF_DWORD, 2:idc.FF_WORD, 1:idc.FF_BYTE, 0:0}
+        flags |= d[value]
+        if not ida_struct.set_member_type(self.struct._struct, self.offset, flags, None, value):
+            raise RuntimeError("Unable to set size for member {}".format(self.fullname))
+
+
     @property
     def offset(self):
         """

--- a/bip/base/bipstruct.py
+++ b/bip/base/bipstruct.py
@@ -722,7 +722,7 @@ class BStructMember(BipRefElt):
         if bytil:
             flags |= 0x08
         if not ida_struct.set_member_tinfo(self.struct._struct, self._member, 0, new_type._get_tinfo_copy(), flags):
-            raise RuntimeError("Unable to set type {} for this {}".format(value, self))
+            raise RuntimeError("Unable to set type {} for this {}".format(new_type.str, self))
 
     @type.setter
     def type(self, value):

--- a/bip/base/bipstruct.py
+++ b/bip/base/bipstruct.py
@@ -3,6 +3,8 @@ import idautils
 import ida_struct
 import ida_typeinf
 
+import re
+
 from bip.py3compat.py3compat import *
 
 from .bipidb import BipIdb
@@ -257,7 +259,7 @@ class BipStruct(BipRefElt):
             equivalent to :meth:`~BipStruct.members_iter`.
 
             .. note::
-            
+
                 By default python will try to use the __getitem__ method
                 which is not what we want because the __getitem__ method takes
                 offset.
@@ -419,6 +421,38 @@ class BipStruct(BipRefElt):
             if sid == idc.BADADDR:
                 continue # error
             yield cls(ida_struct.get_struc(sid))
+
+    @classmethod
+    def get_by_prefix(cls, prefix):
+        """
+            Class method allowing to get all the :class:`BipStruct` which are
+            named with a particular prefix.
+
+            Internally this iterate on all functions.
+
+            :param str prefix: The prefix for which to get the structs.
+            :return: A list of :class:`BipStruct` where their names start
+                with the prefix.
+        """
+        return [s for s in cls.iter_all() if s.name.startswith(prefix)]
+
+    @classmethod
+    def get_by_regex(cls, regex):
+        """
+            Class method allowing to get all :class:`BipStruct` where their
+            names match a regex.
+
+            Internally this iterate on all structs and use the ``re.match``
+            function (it compiles the regex first) and return the struct
+            if the match did not return None.
+
+            :param str regex: The regex used for finding the function.
+            :return: A list of :class:`BipStruct` where their names match
+                the regex.
+        """
+        rc = re.compile(regex)
+        return [s for s in cls.iter_all() if rc.match(s.name) is not None]
+
 
     @staticmethod
     def delete(name):
@@ -733,7 +767,7 @@ class BStructMember(BipRefElt):
         """
             If this member represent a nested structure this property allows
             to get the :class:`BipStruct` corresponding to the nested struct.
-            
+
             :raise RuntimeError: If this member does not have a nested struct.
                 This can be tested using :meth:`~BStructMember.is_nested`.
             :return: An :class:`BipStruct` object corresponding to the nested

--- a/bip/base/biptype.py
+++ b/bip/base/biptype.py
@@ -21,6 +21,8 @@ import ida_nalt
 import ida_kernwin
 import idc
 
+import bip.base.bipstruct
+
 class BipType(object):
     """
         Abstract class for representing a ``tinfo_t`` object from ida in bip.
@@ -127,6 +129,15 @@ class BipType(object):
         """
 
         return self._tinfo.get_type_name()
+
+    @property
+    def final_name(self):
+        """
+            Property which return the final name of this type if it as one.
+            This is similar to :func:`BipType.name` except it will follow the
+            typedef chain and return the last element of the chain.
+        """
+        return self._tinfo.get_final_type_name()
 
     ############################ COMPARE ################################
 
@@ -803,6 +814,31 @@ class BTypeStruct(BipType):
         if not self._tinfo.get_udt_details(utd):
             raise BipError("Unable to get struct details for struct {}".format(self.name))
         return utd
+
+    @property
+    def struct(self):
+        """
+            Getter for recuperating the :class:`BipStruct` associated with this
+            type.
+
+            This recuperate the struct from the name, it will first try to use
+            the current name for getting the :class:`BipStruct` and if not
+            sucessful it will then try to use the final name.
+
+            .. todo:: Better way than this ? using til and ordinal maybe ?
+
+            :return: The :class:`BipStruct` associated with this type or None
+                if it was not possible to get it.
+        """
+        try:
+            return bip.base.bipstruct.BipStruct.get(self.name)
+        except ValueError:
+            pass
+        try:
+            return bip.base.bipstruct.BipStruct.get(self.final_name)
+        except ValueError:
+            pass
+        return None
 
     def get_member_name(self, num):
         """

--- a/bip/base/func.py
+++ b/bip/base/func.py
@@ -986,6 +986,15 @@ class BipFunction(object):
         return l
 
 
+    ######################## GUI ############################
+
+    def goto(self):
+        """
+            Method which allow to move the screen to the position of this
+            function. Wrapper on ``ida_kernwin.jumpto`` (old ``idc.Jump``).
+        """
+        ida_kernwin.jumpto(self.ea)
+
 
     ########################## CLASS METHOD ############################
 

--- a/bip/hexrays/astnode.py
+++ b/bip/hexrays/astnode.py
@@ -210,6 +210,9 @@ class AbstractCItem(object):
 
             This seems to not work if the function has been recompiled.
 
+            .. warning:: This may return True even if the nodes are not at the
+                same address and do not have the same parent
+
             Return ``NotImplemented`` if the element to compare does not
                 inherit from AbstractCItem
         """

--- a/bip/hexrays/hx_cexpr.py
+++ b/bip/hexrays/hx_cexpr.py
@@ -1008,6 +1008,9 @@ class HxCExprCall(HxCExpr):
             Property which return true if this function is a decompiler helper
             function.
 
+            .. todo:: fix this does not work in all case, search for the one
+                where the caller is a CNodeExprHelper (HIDWORD for exemple)
+
             :return: A bool indicating if this is a helper function (true) or
                 a "real" call.
         """

--- a/bip/hexrays/hx_cfunc.py
+++ b/bip/hexrays/hx_cfunc.py
@@ -1,6 +1,8 @@
 import ida_hexrays
 import ida_kernwin
 
+from bip.py3compat.py3compat import *
+
 from .hx_lvar import HxLvar
 from .hx_visitor import _hx_visitor_expr, _hx_visitor_list_expr, _hx_visitor_stmt, _hx_visitor_list_stmt, _hx_visitor_all, _hx_visitor_list_all
 from .cnode import CNode

--- a/test/test_astnode.py
+++ b/test/test_astnode.py
@@ -164,7 +164,7 @@ def test_hxcexprobj00():
     assert isinstance(e, BipElt) and isinstance(e, BipData)
     assert e.ea == 0x018015D228
     s = HxCFunc.from_addr(0x0180053BA0).get_cnode_filter_type(CNodeExprCall)[0].get_arg(1).value_as_cstring
-    assert s == 'SE_InitializeEngine'
+    assert s == b'SE_InitializeEngine'
 
 
 

--- a/test/test_bipelt.py
+++ b/test/test_bipelt.py
@@ -207,7 +207,8 @@ def test_bipelt07():
     assert BipElt(0x01800D3242).xEltFrom == [BipElt(0x01800D3248)]
     assert BipElt(0x01800D3242).xCodeFrom == [BipInstr(0x1800D3248)]
     assert BipElt(0x01800D3242).xFuncFrom == [BipFunction(0x1800D2FF0)]
-    assert BipElt(0x01800D324E).xFuncFrom == [BipFunction(0x1800D2FF0), BipFunction(0x1800D35E8)]
+    assert ((BipElt(0x01800D324E).xFuncFrom == [BipFunction(0x1800D2FF0), BipFunction(0x1800D35E8)])
+        or (BipElt(0x01800D324E).xFuncFrom == [BipFunction(0x1800D35E8), BipFunction(0x1800D2FF0)]))
     assert BipElt(0x01800D323A).xFuncFrom == [BipFunction(0x1800D2FF0)]
     assert BipElt(0x018015D238).xFuncFrom == []
     assert len(BipElt(0x01800D3242).xTo) == 1
@@ -306,5 +307,62 @@ def test_bipelt09():
     elt = next(gen)
     assert elt.__class__ == BipInstr
     assert elt.ea == 0x180001012
+
+def test_bipelt0A():
+    # test for iter_by_regex, get_by_regex, iter_by_prefix, get_by_prefix
+    lp = BipElt.get_by_prefix("jpt_")
+    assert isinstance(lp, list)
+    assert len(lp) == 7
+    i = BipElt.iter_by_prefix("jpt_")
+    c = 0
+    for elt in i:
+        assert elt == lp[c]
+        assert elt.name[:4] == "jpt_"
+        assert elt.__class__ == BipData
+        c += 1
+    lp = BipElt.get_by_prefix("def_")
+    assert isinstance(lp, list)
+    assert len(lp) == 7
+    i = BipElt.iter_by_prefix("def_")
+    c = 0
+    for elt in i:
+        assert elt == lp[c]
+        assert elt.__class__ == BipInstr
+        assert elt.name[:4] == "def_"
+        c += 1
+    lp = BipElt.get_by_prefix("RtlNt")
+    assert len(lp) == 4
+    assert lp[0].__class__ == BipInstr
+    assert lp[-1].__class__ == BipData
+    lp = BipInstr.get_by_prefix("RtlNt")
+    assert len(lp) == 3
+    for i in lp:
+        assert i.__class__ == BipInstr
+    lp = BipData.get_by_prefix("RtlNt")
+    assert len(lp) == 1
+    assert lp[0].__class__ == BipData
+    lp = BipElt.get_by_regex(".*rame$")
+    assert isinstance(lp, list)
+    assert len(lp) == 6
+    i = BipElt.iter_by_regex(".*rame$")
+    c = 0
+    for elt in i:
+        assert elt == lp[c]
+        assert elt.__class__ in (BipData, BipInstr)
+        assert elt.name[-4:] == "rame"
+        c += 1
+    lp = BipInstr.get_by_regex(".*rame$")
+    assert len(lp) == 3
+    for elt in lp:
+        assert elt.__class__ == BipInstr
+        assert elt.name[-4:] == "rame"
+    lp = BipData.get_by_regex(".*rame$")
+    assert len(lp) == 3
+    for elt in lp:
+        assert elt.__class__ == BipData
+        assert elt.name[-4:] == "rame"
+
+
+
 
 

--- a/test/test_bipstruct.py
+++ b/test/test_bipstruct.py
@@ -25,7 +25,14 @@ def test_bipstruct00():
     st = BipStruct.get("newStruct")
     assert isinstance(st, BipStruct)
     assert len([s for s in BipStruct.iter_all()]) == 0x16
+    assert len(BipStruct.get_by_prefix("UNWIND_")) == 3
+    assert len(BipStruct.get_by_regex(".*UNWIND")) == 4
+    assert len(BipStruct.get_by_regex("^_UNWIND")) == 1
+    assert len(BipStruct.get_by_regex(".*TABLE$")) == 2
+    assert len(BipStruct.get_by_prefix("new")) == 1
+    assert BipStruct.get_by_prefix("new")[0].name == "newStruct"
     BipStruct.delete("newStruct")
+    assert len(BipStruct.get_by_prefix("new")) == 0
     with pytest.raises(ValueError): BipStruct.get("newStruct")
     with pytest.raises(ValueError): BipStruct.delete("newStruct")
 

--- a/test/test_bipstruct.py
+++ b/test/test_bipstruct.py
@@ -31,7 +31,9 @@ def test_bipstruct00():
     assert len(BipStruct.get_by_regex(".*TABLE$")) == 2
     assert len(BipStruct.get_by_prefix("new")) == 1
     assert BipStruct.get_by_prefix("new")[0].name == "newStruct"
+    assert BipStruct.exist("newStruct")
     BipStruct.delete("newStruct")
+    assert BipStruct.exist("newStruct") == False
     assert len(BipStruct.get_by_prefix("new")) == 0
     with pytest.raises(ValueError): BipStruct.get("newStruct")
     with pytest.raises(ValueError): BipStruct.delete("newStruct")

--- a/test/test_bipstruct.py
+++ b/test/test_bipstruct.py
@@ -197,3 +197,18 @@ def test_bstructmember03():
     assert BStructMember._is_member_id(0x1800D3242) == False
     
 
+def test_bstructmember04():
+    st = BipStruct.create("newStruct")
+    assert st.size == 0
+    st.fill(0x10)
+    assert st.size == 0x10
+    assert st[0].size == 8
+    st[0].size = 4
+    assert st[0].size == 4
+    with pytest.raises(IndexError): st[4]
+    st.add(None, 4, offset=4)
+    assert st[4].size == 4
+    with pytest.raises(ValueError): st[0].size = 9
+    with pytest.raises(RuntimeError): st[0].size = 8
+    with pytest.raises(RuntimeError): st[0].size = 0
+    BipStruct.delete("newStruct")

--- a/test/test_bipstruct.py
+++ b/test/test_bipstruct.py
@@ -187,6 +187,7 @@ def test_bstructmember02():
     m.del_type()
     assert m.has_type == False
     with pytest.raises(RuntimeError): m.type
+    with pytest.raises(RuntimeError): m.type = "void __fastcall f()"
     m.type = "DWORD"
     assert m.has_type == True
     assert m.type.str == 'DWORD'

--- a/test/test_biptype.py
+++ b/test/test_biptype.py
@@ -299,5 +299,12 @@ def test_biptype10():
     assert ty.get_str_named(name="f", comment = "com") == 'void (__stdcall *f)(int a, void *b) /* com */'
 
 
+def test_biptype11():
+    # test link to struct and final_name
+    assert BipType.from_c("_UNWIND_HISTORY_TABLE").struct == BipStruct.get("_UNWIND_HISTORY_TABLE")
+    assert BipType.from_c("EXCEPTION_RECORD").name == "EXCEPTION_RECORD"
+    assert BipType.from_c("EXCEPTION_RECORD").final_name == "_EXCEPTION_RECORD"
+    assert BipType.from_c("EXCEPTION_RECORD").struct == BipStruct.get("EXCEPTION_RECORD")
+
 
 


### PR DESCRIPTION
This PR includes the following changes:

* For `BipStruct`, `BStructMember` and `BipType`:
  * add a `size` setter for `BStructMember`
  * add an `exists` class method for `BipStruct`
  * add class methods `get_by_regex` and `get_by_prefix` for `BipStruct`
  * add faster way to get the `BipStruct` from a `BTypeStruct` (`struct` and `final_name` properties)
* Add `goto` method for `BipFunction`
* Add `get_by_regex`, `iter_by_regex`, `iter_by_prefix` and `get_by_prefix` for `BipElt`
* Add tests for all of those
* Add python3 compatibility layer to `hx_cfunc.py`
* Fix a test for python3 which where not working correctly
