### PR TITLE
Indication of stop for `visit_cnode` functions

### DIFF
--- a/bip/hexrays/cnode.py
+++ b/bip/hexrays/cnode.py
@@ -192,8 +192,9 @@ class CNode(AbstractCItem):
                 argument which correspond to the :class:`CNode` currently
                 visited. If this callback return False the visit is stoped,
                 all other result is ignored.
+            :return: True if the visit got to the end, False otherwise.
         """
-        cnode_visitor.visit_dfs_cnode(self, callback)
+        return cnode_visitor.visit_dfs_cnode(self, callback)
 
     def visit_cnode_filterlist(self, callback, filter_list):
         """
@@ -213,8 +214,9 @@ class CNode(AbstractCItem):
             :param filter_list: A list of class which inherit from :class:`CNode`.
                 The callback will be called only for the node from a class in this
                 list.
+            :return: True if the visit got to the end, False otherwise.
         """
-        cnode_visitor.visit_dfs_cnode_filterlist(self, callback, filter_list)
+        return cnode_visitor.visit_dfs_cnode_filterlist(self, callback, filter_list)
 
     def get_cnode_filter(self, cb_filter):
         """

--- a/bip/hexrays/cnode_visitor.py
+++ b/bip/hexrays/cnode_visitor.py
@@ -34,6 +34,8 @@ def visit_dfs_cnode(cnode, callback):
         :param callback: A callable taking one argument which will be called
             on all the :class:`CNode` visited with the :class:`CNode` as
             argument. If it returns False the visitor stops.
+        :return: True if the visit got to the end, False if it was stopped
+            by the ``callback``.
     """
     # implem using a stack for avoiding recursivity problems
     # this is a tree so no need to check if we have already treated a node.
@@ -41,7 +43,7 @@ def visit_dfs_cnode(cnode, callback):
     while len(stack) != 0:
         elt = stack.pop() # get the next element
         if callback(elt) == False: # call the callback before visiting the next
-            return # if ret False: stop
+            return False # if ret False: stop
         if isinstance(elt, bip.hexrays.cnode.CNodeExpr):
             # if we have an expr just append all the child, we append them
             #   in reverse order.
@@ -56,6 +58,7 @@ def visit_dfs_cnode(cnode, callback):
         else:
             # this should never happen
             raise RuntimeError("Unknown type for visiting: {}".format(elt))
+    return True
 
 def visit_dfs_cnode_filterlist(cnode, callback, filter_list):
     """
@@ -80,10 +83,12 @@ def visit_dfs_cnode_filterlist(cnode, callback, filter_list):
         :param filter_list: A list or tuple of class or a class which inherit
             from :class:`CNode`. The callback will be called only for the node
             from a class in this list. If it returns False the visitor stops.
+        :return: True if the visit got to the end, False if it was stopped
+            by the ``callback``.
     """
     if isinstance(filter_list, (list, tuple)) and len(filter_list) == 0:
         # we don't visit anything
-        return
+        return True
     # check if we need to visit the child of the expression
     vist_expr = False
     if isinstance(filter_list, (list, tuple)):
@@ -102,7 +107,7 @@ def visit_dfs_cnode_filterlist(cnode, callback, filter_list):
                 and isinstance(elt, filter_list))):
             # check if we want the call
             if callback(elt) == False: # call the callback before visiting the next
-                return
+                return False
         if isinstance(elt, bip.hexrays.cnode.CNodeExpr):
             if vist_expr:
                 ch = list(elt.ops)
@@ -119,5 +124,6 @@ def visit_dfs_cnode_filterlist(cnode, callback, filter_list):
         else:
             # this should never happen
             raise RuntimeError("Unknown type for visiting: {}".format(elt))
+    return True
 
 

--- a/bip/hexrays/hx_cfunc.py
+++ b/bip/hexrays/hx_cfunc.py
@@ -228,8 +228,10 @@ class HxCFunc(object):
                 should take only one argument which correspond to the
                 :class:`CNode` currently visited. If this callback return
                 False the visit is stoped, all other result is ignored.
+            :return: True if the visit got to the end, False otherwise (
+                interupted by the ``callback``).
         """
-        self.root_node.visit_cnode(callback)
+        return self.root_node.visit_cnode(callback)
 
     def visit_cnode_filterlist(self, callback, filter_list):
         """
@@ -248,8 +250,10 @@ class HxCFunc(object):
             :param filter_list: A list of class which inherit from :class:`CNode`.
                 The callback will be called only for the node from a class in this
                 list.
+            :return: True if the visit got to the end, False otherwise (
+                interupted by the ``callback``).
         """
-        self.root_node.visit_cnode_filterlist(callback, filter_list)
+        return self.root_node.visit_cnode_filterlist(callback, filter_list)
 
     def get_cnode_filter(self, cb_filter):
         """

--- a/test/test_astnode.py
+++ b/test/test_astnode.py
@@ -129,13 +129,13 @@ def test_bipcnodevisitor00():
     #   of the CNode functions this is considered enough. Internally those
     #   use the functions in cnode_visitor.py
     hxf = HxCFunc.from_addr(0x01800D2FF0)
-    hxf.visit_cnode(genst_all)
+    assert hxf.visit_cnode(genst_all)
     def _intern_testfilter(cn):
         assert isinstance(cn, (CNodeExprCall, CNodeStmtExpr)) 
         genst_all(cn)
-    hxf.visit_cnode_filterlist(_intern_testfilter, [CNodeExprCall, CNodeStmtExpr])
+    assert hxf.visit_cnode_filterlist(_intern_testfilter, [CNodeExprCall, CNodeStmtExpr])
     hxf = HxCFunc.from_addr(0x0180002524)
-    hxf.visit_cnode(genst_all)
+    assert hxf.visit_cnode(genst_all)
     ln = hxf.get_cnode_filter_type([CNodeStmtReturn])
     for cnr in ln:
         cn = cnr.value
@@ -153,7 +153,26 @@ def test_bipcnodevisitor00():
     assert len(ln) == 1
     assert isinstance(ln[0], CNodeExprHelper)
     hxf = HxCFunc.from_addr(0x018009BF50)
-    hxf.visit_cnode(genst_all)
+    assert hxf.visit_cnode(genst_all)
+
+def test_bipcnodevisitor01():
+    # test for interrupting the visitor cnodes
+    hxf = HxCFunc.from_addr(0x01800D2FF0)
+    def _interupt_stmt(cn):
+        if isinstance(cn, CNodeStmt):
+            return False
+    d = {}; d["counter"] = 0
+    def _interupt_expr_cnt(cn):
+        #nonlocal counter # only py3
+        if isinstance(cn, CNodeStmt):
+            d["counter"] += 1
+        else:
+            return False
+    assert not hxf.visit_cnode(_interupt_stmt)
+    assert d["counter"] == 0
+    assert not hxf.visit_cnode(_interupt_expr_cnt)
+    assert d["counter"] != 0
+    d["counter"] = 0
 
 def test_hxcexprobj00():
     # Specific test for methods implemented in HxCExprObj/CNodeExprObj


### PR DESCRIPTION
Fix for #23.

* bip/hexrays: add return value to the `visit_cnode*` functions, will return False when interupted by the callback, True otherwise
* test: add revelant test for the return value